### PR TITLE
feat(rex): implement ScheduleNews support

### DIFF
--- a/Console/Commands/ResourceExCommands.cs
+++ b/Console/Commands/ResourceExCommands.cs
@@ -142,6 +142,7 @@ public static class ResourceExCommands
         if (config?.dialogPackages?.Count > 0) parts.Add($"Dialogs: {config.dialogPackages.Count}");
         if (config?.missionNodes?.Count > 0) parts.Add($"Missions: {config.missionNodes.Count}");
         if (config?.eventNodes?.Count > 0) parts.Add($"Events: {config.eventNodes.Count}");
+        if (config?.newsNodes?.Count > 0) parts.Add($"News: {config.newsNodes.Count}");
         if (config?.merchants?.Count > 0) parts.Add($"Merchants: {config.merchants.Count}");
         if (config?.clothes?.Count > 0) parts.Add($"Clothes: {config.clothes.Count}");
 

--- a/ResourceEx/Core.cs
+++ b/ResourceEx/Core.cs
@@ -54,6 +54,7 @@ public static partial class ResourceExManager
     private static Dictionary<int, RecipeConfig> RecipeConfigs = new Dictionary<int, RecipeConfig>();
     private static List<MissionNodeConfig> MissionNodeConfigs = new List<MissionNodeConfig>();
     private static List<EventNodeConfig> EventNodeConfigs = new List<EventNodeConfig>();
+    private static List<NewsNodeConfig> NewsNodeConfigs = new List<NewsNodeConfig>();
     private static Dictionary<string, MerchantConfig> MerchantConfigs = new Dictionary<string, MerchantConfig>();
     private static Dictionary<int, ClothConfig> ClothConfigs = new Dictionary<int, ClothConfig>();
 
@@ -104,6 +105,7 @@ public static partial class ResourceExManager
         RegisterAllBeverageLanguages();
         RegisterAllFoodLanguages();
         RegisterAllMissionNodeLanguages();
+        RegisterAllNewsNodeLanguages();
         RegisterAllClothLanguages();
     }
 
@@ -115,6 +117,7 @@ public static partial class ResourceExManager
 
         RegisterAllMissionNodes(); // 依赖 Dialog
         RegisterAllEventNodes(); // 依赖 Dialog
+        RegisterAllNewsNodes();
 
         RegisterAllClothPixelSprites(); // 依赖 DataBaseCharacter
     }
@@ -129,6 +132,7 @@ public static partial class ResourceExManager
         // RegisterAllEventNodes(); // 依赖 Dialog
         RegisterAllMissionNodesMapping();
         RegisterAllEventNodesMapping();
+        RegisterAllNewsNodesMapping();
     }
     public static void OnNightSceneLanguageInitialized()
     {
@@ -280,6 +284,15 @@ public static partial class ResourceExManager
             {
                 EventNodeConfigs.Add(eventNodeConfig);
                 Log.LogInfo($"[{packageName}] Loaded config for event node {eventNodeConfig.debugLabel}");
+            }
+        }
+
+        if (config?.newsNodes != null)
+        {
+            foreach (var newsNodeConfig in config.newsNodes)
+            {
+                NewsNodeConfigs.Add(newsNodeConfig);
+                Log.LogInfo($"[{packageName}] Loaded config for news node {newsNodeConfig.title}({newsNodeConfig.label})");
             }
         }
 

--- a/ResourceEx/Mappers/Mappers.cs
+++ b/ResourceEx/Mappers/Mappers.cs
@@ -240,6 +240,24 @@ public static partial class Mappers
 
     #endregion
 
+    #region NewsNode Mappers
+
+    public static LanguageBase ToNewsLanguage(this NewsNodeConfig config)
+    {
+        return new LanguageBase(config.title, config.description);
+    }
+
+    public static NewsNode ToNewsNode(this NewsNodeConfig config)
+    {
+        var newsNode = ScriptableObject.CreateInstance<NewsNode>();
+        newsNode.name = config.label;
+        newsNode.label = config.label;
+        newsNode.debugLabel = config.debugLabel ?? config.label ?? "";
+        return newsNode;
+    }
+
+    #endregion
+
     #region EventNode Mappers
 
     public static EventNode ToEventNode(this EventNodeConfig config)

--- a/ResourceEx/Models.cs
+++ b/ResourceEx/Models.cs
@@ -172,6 +172,7 @@ public class ResourceConfig
     public List<ClothConfig> clothes { get; set; }
     public List<MissionNodeConfig> missionNodes { get; set; }
     public List<EventNodeConfig> eventNodes { get; set; }
+    public List<NewsNodeConfig> newsNodes { get; set; }
     public List<MerchantConfig> merchants { get; set; }
 }
 
@@ -339,6 +340,14 @@ public class EventNodeConfig
     public List<MissionRewardConfig> postRewards { get; set; }
     public List<string> postMissionsAfterPerformance { get; set; }
     public List<string> postEvents { get; set; }
+}
+
+public class NewsNodeConfig
+{
+    public string label { get; set; }
+    public string debugLabel { get; set; }
+    public string title { get; set; }
+    public string description { get; set; }
 }
 
 public class DayConfig

--- a/ResourceEx/NewsNode.cs
+++ b/ResourceEx/NewsNode.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GameData.Core.Collections;
+using GameData.CoreLanguage.Collections;
+using GameData.Profile;
+using GameData.Profile.SchedulerNodeCollection;
+using GameData.RunTime.Common;
+using MetaMystia.ResourceEx.Mappers;
+using MetaMystia.ResourceEx.Models;
+
+namespace MetaMystia;
+
+public static partial class ResourceExManager
+{
+    private static void RegisterAllNewsNodeLanguages() => NewsNodeConfigs.ToList().ForEach(RegisterNewsNodeLanguage);
+
+    private static void RegisterNewsNodeLanguage(NewsNodeConfig config)
+    {
+        var lang = config.ToNewsLanguage();
+        DataBaseLanguage.News[config.label] = lang;
+        Log.Info($"Registered NewsNode language {config.title}({config.label})");
+    }
+
+    private static void RegisterAllNewsNodes() => NewsNodeConfigs.ToList().ForEach(RegisterNewsNode);
+
+    private static void RegisterNewsNode(NewsNodeConfig config)
+    {
+        var newsNode = config.ToNewsNode();
+        DataBaseScheduler.newsNodes[newsNode.label] = newsNode;
+        Log.Info($"Registered NewsNode {config.title}({config.label})");
+    }
+
+    private static void RegisterAllNewsNodesMapping() => NewsNodeConfigs.ToList().ForEach(RegisterNewsNodeMapping);
+
+    private static void RegisterNewsNodeMapping(NewsNodeConfig config)
+    {
+        try
+        {
+            DataBaseScheduler.NewsNodesMapping[config.label] = "ResourceEx";
+        }
+        catch (Exception ex)
+        {
+            Log.Error($"Failed to register NewsNode mapping for {config.label}: {ex.Message}");
+        }
+    }
+
+    public static List<string> GetAllNewsNodeLabels() => NewsNodeConfigs.Select(config => config.label).ToList();
+
+    public static bool IsResourceNewsLoaded(string newsLabel) => GetAllNewsNodeLabels().Contains(newsLabel);
+
+    public static bool ScheduleResourceNews(string newsLabel, SchedulerNode.Day targetDate, params RunTimeScheduler.HistoryNewsData.ReplaceContent[] replaceContents)
+    {
+        if (!IsResourceNewsLoaded(newsLabel))
+        {
+            Log.Warning($"Will not schedule unloaded ResourceEx news: {newsLabel}");
+            return false;
+        }
+
+        RunTimeScheduler.ScheduleNews(newsLabel, targetDate, replaceContents ?? Array.Empty<RunTimeScheduler.HistoryNewsData.ReplaceContent>());
+        return true;
+    }
+
+    public static bool ScheduleResourceNewsTomorrow(string newsLabel, params RunTimeScheduler.HistoryNewsData.ReplaceContent[] replaceContents)
+    {
+        var targetDate = new SchedulerNode.Day
+        {
+            dayType = SchedulerNode.Day.DayType.Absolute,
+            dayCalcType = SchedulerNode.Day.CalculateType.Constant,
+            day = RunTimePlayerData.GetDay().CorrectedDay + 1
+        };
+        return ScheduleResourceNews(newsLabel, targetDate, replaceContents);
+    }
+
+    public static bool DismissResourceNews(string newsLabel)
+    {
+        if (RunTimeScheduler.scheduledNews == null)
+        {
+            return false;
+        }
+
+        var removed = false;
+        foreach (var newsList in RunTimeScheduler.scheduledNews.Values)
+        {
+            while (newsList.Remove(newsLabel))
+            {
+                removed = true;
+            }
+        }
+
+        if (RunTimeScheduler.scheduledNewsReplaceContents != null)
+        {
+            foreach (var replaceList in RunTimeScheduler.scheduledNewsReplaceContents.Values)
+            {
+                for (var i = replaceList.Count - 1; i >= 0; i--)
+                {
+                    if (replaceList[i].Key == newsLabel)
+                    {
+                        replaceList.RemoveAt(i);
+                        removed = true;
+                    }
+                }
+            }
+        }
+
+        if (removed)
+        {
+            Log.Info($"Dismissed scheduled ResourceEx news: {newsLabel}");
+        }
+        return removed;
+    }
+}

--- a/ResourceEx/Scheduler.cs
+++ b/ResourceEx/Scheduler.cs
@@ -1,6 +1,4 @@
-using System.Linq;
-using Newtonsoft.Json.Utilities;
-using SgrYuki.Utils;
+using Il2CppInterop.Runtime.InteropTypes.Arrays;
 using GameData.RunTime.Common;
 
 
@@ -31,6 +29,11 @@ public static partial class ResourceExManager
             foreach (var scheduledEvent in dlcData.scheduledEvents)
             {
                 Log.Warning($"  - {scheduledEvent}");
+            }
+            Log.Warning($"scheduledNews count: {dlcData.scheduledNews.Count}");
+            foreach (var scheduledNews in dlcData.scheduledNews)
+            {
+                Log.Warning($"  - {scheduledNews}");
             }
             Log.Warning($"allTrackingMissions count: {dlcData.allTrackingMissions.Count}");
             foreach (var allTrackingMission in dlcData.allTrackingMissions)
@@ -117,6 +120,51 @@ public static partial class ResourceExManager
             }
         }
 
+        // reload scheduledNews
+        foreach (var scheduledNews in resourceExData.scheduledNews)
+        {
+            if (!RunTimeScheduler.scheduledNews.ContainsKey(scheduledNews.Key))
+            {
+                RunTimeScheduler.scheduledNews.Add(scheduledNews.Key, new Il2CppSystem.Collections.Generic.List<string>());
+                Log.Info($"Added new scheduledNews key: {scheduledNews.Key}");
+            }
+
+            var targetList = RunTimeScheduler.scheduledNews[scheduledNews.Key];
+            foreach (var newsLabel in scheduledNews.Value)
+            {
+                if (!targetList.Contains(newsLabel) && GetAllNewsNodeLabels().Contains(newsLabel))
+                {
+                    targetList.Add(newsLabel);
+                    Log.Info($"Reloaded scheduledNews: {newsLabel} under key: {scheduledNews.Key}");
+                }
+            }
+        }
+
+        // reload scheduledNewsReplaceContents
+        foreach (var scheduledNewsReplaceContent in resourceExData.scheduledNewsReplaceContents)
+        {
+            if (!RunTimeScheduler.scheduledNewsReplaceContents.ContainsKey(scheduledNewsReplaceContent.Key))
+            {
+                RunTimeScheduler.scheduledNewsReplaceContents.Add(scheduledNewsReplaceContent.Key, new Il2CppSystem.Collections.Generic.List<Il2CppSystem.Collections.Generic.KeyValuePair<string, Il2CppReferenceArray<RunTimeScheduler.HistoryNewsData.ReplaceContent>>>());
+                Log.Info($"Added new scheduledNewsReplaceContents key: {scheduledNewsReplaceContent.Key}");
+            }
+
+            var targetList = RunTimeScheduler.scheduledNewsReplaceContents[scheduledNewsReplaceContent.Key];
+            foreach (var replaceContent in scheduledNewsReplaceContent.Value)
+            {
+                if (!GetAllNewsNodeLabels().Contains(replaceContent.Key))
+                {
+                    continue;
+                }
+
+                if (!ContainsNewsReplaceContent(targetList, replaceContent.Key))
+                {
+                    targetList.Add(replaceContent);
+                    Log.Info($"Reloaded scheduledNewsReplaceContents: {replaceContent.Key} under key: {scheduledNewsReplaceContent.Key}");
+                }
+            }
+        }
+
         // reload allTrackingMissions
         foreach (var trackingMission in resourceExData.allTrackingMissions)
         {
@@ -138,5 +186,17 @@ public static partial class ResourceExManager
         }
         notLoadedDLCSchedulerSaveData.Remove("ResourceEx");
         Log.Info("ResourceEx Scheduler data has been successfully reloaded.");
+    }
+
+    private static bool ContainsNewsReplaceContent(Il2CppSystem.Collections.Generic.List<Il2CppSystem.Collections.Generic.KeyValuePair<string, Il2CppReferenceArray<RunTimeScheduler.HistoryNewsData.ReplaceContent>>> list, string newsLabel)
+    {
+        for (var i = 0; i < list.Count; i++)
+        {
+            if (list[i].Key == newsLabel)
+            {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
「文々。新聞」業務再開のお知らせ！

- Introduce NewsNodeConfig and NewsNode models for custom news data.
- Implement registration methods for news languages, nodes, and mappings.
- Add utility helpers: ScheduleResourceNews, ScheduleResourceNewsTomorrow, and DismissResourceNews.
- Add support for serialization and reloading of scheduled news and their replace contents within the Scheduler.
- Update ResourceExCommands to display the loaded news nodes count.