### PR TITLE
feat(rex): support location-gated special guest spawning

### DIFF
--- a/src/MetaMystia.Mod/Patches/RunTime/RunTimeAlbumPatch.cs
+++ b/src/MetaMystia.Mod/Patches/RunTime/RunTimeAlbumPatch.cs
@@ -10,6 +10,55 @@ namespace MetaMystia.Patch;
 [AutoLog]
 public partial class RunTimeAlbumPatch
 {
+    [HarmonyPatch(nameof(RunTimeAlbum.RefSpecialNPCId), [typeof(string)])]
+    [HarmonyPrefix]
+    public static bool RefSpecialNPCId_Prefix(string characterLabel, ref int __result)
+    {
+        var config = ResourceExManager.GetCharacterConfig(characterLabel);
+        if (config == null) return true;
+
+        __result = config.id;
+        return false;
+    }
+
+    [HarmonyPatch(nameof(RunTimeAlbum.RefOrGenerateSpecialRunTimeData), [typeof(string)])]
+    [HarmonyPrefix]
+    public static bool RefOrGenerateSpecialRunTimeData_Prefix(
+        string npcLabel,
+        ref RunTimeAlbum.SpecialGuestRunTimeData __result)
+    {
+        var config = ResourceExManager.GetCharacterConfig(npcLabel);
+        if (config == null) return true;
+
+        __result = RunTimeAlbum.RefOrGenerateSpecialRunTimeData(config.id);
+        return false;
+    }
+
+    [HarmonyPatch(nameof(RunTimeAlbum.IfGuestHaveSpawnHere), [typeof(string), typeof(int)])]
+    [HarmonyPrefix]
+    public static bool IfGuestHaveSpawnHere_Prefix(
+        string specialGuestLabel,
+        int izakayaId,
+        ref bool __result)
+    {
+        var config = ResourceExManager.GetCharacterConfig(specialGuestLabel);
+        if (config == null) return true;
+
+        __result = RunTimeAlbum.IfGuestHaveSpawnHere(config.id, izakayaId);
+        return false;
+    }
+
+    [HarmonyPatch(nameof(RunTimeAlbum.SetGuestSpawnIzakayaId), [typeof(string), typeof(int)])]
+    [HarmonyPrefix]
+    public static bool SetGuestSpawnIzakayaId_Prefix(string specialGuestLabel, int izakayaId)
+    {
+        var config = ResourceExManager.GetCharacterConfig(specialGuestLabel);
+        if (config == null) return true;
+
+        RunTimeAlbum.SetGuestSpawnIzakayaId(config.id, izakayaId);
+        return false;
+    }
+
     [HarmonyPatch(nameof(RunTimeAlbum.ChangePlayerSkin))]
     [HarmonyPostfix]
     public static void ChangePlayerSkin_Postfix(int skinSelectionInfo)

--- a/src/MetaMystia.Mod/ResourceEx/Mappers/Mappers.cs
+++ b/src/MetaMystia.Mod/ResourceEx/Mappers/Mappers.cs
@@ -173,6 +173,11 @@ public static partial class Mappers
             case RewardType.UpgradeKizunaLevel:
                 reward.rewardId = config.rewardId;
                 break;
+            case RewardType.EnableSGuestSpawnInTargetIzakayaById:
+                reward.rewardId = config.rewardId;
+                reward.rewardIntArray = config.rewardIntArray?.ToArray() ?? new int[0];
+                reward.should = config.should ?? true;
+                break;
             case RewardType.GiveItem:
                 reward.objectType = config.objectType ?? ObjectType.Food;
                 reward.rewardIntArray = config.rewardIntArray?.ToArray() ?? new int[0];

--- a/src/MetaMystia.Mod/ResourceEx/Models/MissionNodeConfigs.cs
+++ b/src/MetaMystia.Mod/ResourceEx/Models/MissionNodeConfigs.cs
@@ -37,6 +37,7 @@ public class MissionRewardConfig
     public string rewardId { get; set; }
     public Reward.ObjectType? objectType { get; set; }
     public List<int> rewardIntArray { get; set; }
+    public bool? should { get; set; }
 }
 
 public class MissionFinishConditionConfig


### PR DESCRIPTION
Add support for EnableSGuestSpawnInTargetIzakayaById rewards, including target izakaya lists and optional night-spawn enabling.

Resolve ResourceEx special guest labels through their configured character IDs when accessing runtime album data, allowing location unlock rewards and notifications to work without native DataBaseDay NPC registration.